### PR TITLE
Fix exec format error after running docker-compose up

### DIFF
--- a/api/run.py
+++ b/api/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from flask_failsafe import failsafe
 
 


### PR DESCRIPTION
Not sure if anyone else was getting this after running `docker-compose up`. But I followed the fix from this [link ](https://stackoverflow.com/questions/55271912/flask-cli-throws-oserror-errno-8-exec-format-error-when-run-through-docker) and it seems to have fixed it. Since we're using Python 2.7 I used `python` instead of `python3` though.

```
web_1      | postgres://docker:docker@172.17.0.4/docker
web_1      |  * Serving Flask app "app" (lazy loading)
web_1      |  * Environment: production
web_1      |    WARNING: Do not use the development server in a production environment.
web_1      |    Use a production WSGI server instead.
web_1      |  * Debug mode: on
web_1      |  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
web_1      |  * Restarting with stat
web_1      | Traceback (most recent call last):
web_1      |   File "./api/run.py", line 11, in <module>
web_1      |     create_app().run()
web_1      |   File "/usr/local/lib/python2.7/dist-packages/flask_script/__init__.py", line 417, in run
web_1      |     result = self.handle(argv[0], argv[1:])
web_1      |   File "/usr/local/lib/python2.7/dist-packages/flask_script/__init__.py", line 386, in handle
web_1      |     res = handle(*args, **config)
web_1      |   File "/usr/local/lib/python2.7/dist-packages/flask_script/commands.py", line 479, in __call__
web_1      |     **self.server_options)
web_1      |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 943, in run
web_1      |     run_simple(host, port, self, **options)
web_1      |   File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 988, in run_simple
web_1      |     run_with_reloader(inner, extra_files, reloader_interval, reloader_type)
web_1      |   File "/usr/local/lib/python2.7/dist-packages/werkzeug/_reloader.py", line 332, in run_with_reloader
web_1      |     sys.exit(reloader.restart_with_reloader())
web_1      |   File "/usr/local/lib/python2.7/dist-packages/werkzeug/_reloader.py", line 176, in restart_with_reloader
web_1      |     exit_code = subprocess.call(args, env=new_environ, close_fds=False)
web_1      |   File "/usr/lib/python2.7/subprocess.py", line 172, in call
web_1      |     return Popen(*popenargs, **kwargs).wait()
web_1      |   File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
web_1      |     errread, errwrite)
web_1      |   File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
web_1      |     raise child_exception
web_1      | OSError: [Errno 8] Exec format error
```