### PR TITLE
Count allocated and completed reviews per reviewer

### DIFF
--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -247,7 +247,7 @@ class ReviewResponseAPI(GetReviewResponseMixin, PostReviewResponseMixin, restful
 
 class ReviewCountView():
     def __init__(self, count):
-        self.email = count.email.encode('utf-8')
+        self.email = count.email
         self.user_title = count.user_title
         self.firstname = count.firstname
         self.lastname = count.lastname

--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -280,7 +280,6 @@ class ReviewAssignmentAPI(GetReviewAssignmentMixin, PostReviewAssignmentMixin, r
         counts = review_repository.count_reviews_allocated_and_completed_per_reviewer(event_id)
         views = [ReviewCountView(count) for count in counts]
         return views
-        
 
     @auth_required
     def post(self):

--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -8,8 +8,9 @@ from app import db, LOGGER
 from app.applicationModel.models import ApplicationForm
 from app.events.models import EventRole
 from app.responses.models import Response, ResponseReviewer
-from app.reviews.mixins import ReviewMixin, GetReviewResponseMixin, PostReviewResponseMixin, PostReviewAssignmentMixin
+from app.reviews.mixins import ReviewMixin, GetReviewResponseMixin, PostReviewResponseMixin, PostReviewAssignmentMixin, GetReviewAssignmentMixin
 from app.reviews.models import ReviewForm, ReviewResponse, ReviewScore
+from app.reviews.repository import ReviewRepository as review_repository
 from app.users.models import AppUser
 from app.users.repository import UserRepository as user_repository
 from app.utils.auth import auth_required
@@ -243,8 +244,44 @@ class ReviewResponseAPI(GetReviewResponseMixin, PostReviewResponseMixin, restful
     def get_error_message(self, key):
         return ({'message': {key: 'Missing required parameter in the JSON body or the post body or the query string'}}, 400)
 
-class ReviewAssignmentAPI(PostReviewAssignmentMixin, restful.Resource):
+
+class ReviewCountView():
+    def __init__(self, count):
+        self.email = count.email.encode('utf-8')
+        self.user_title = count.user_title
+        self.firstname = count.firstname
+        self.lastname = count.lastname
+        self.reviews_allocated = count.reviews_allocated
+        self.reviews_completed = count.reviews_completed
+
+
+class ReviewAssignmentAPI(GetReviewAssignmentMixin, PostReviewAssignmentMixin, restful.Resource):
     
+    reviews_count_fields = {
+        'email': fields.String,
+        'user_title': fields.String,
+        'firstname': fields.String,
+        'lastname': fields.String,
+        'reviews_allocated': fields.Integer,
+        'reviews_completed': fields.Integer
+    }
+
+    @auth_required
+    @marshal_with(reviews_count_fields)
+    def get(self):
+        args = self.get_req_parser.parse_args()
+        event_id = args['event_id']
+        user_id = g.current_user['id']
+
+        current_user = user_repository.get_by_id(user_id)
+        if not current_user.is_event_admin(event_id):
+            return FORBIDDEN
+
+        counts = review_repository.count_reviews_allocated_and_completed_per_reviewer(event_id)
+        views = [ReviewCountView(count) for count in counts]
+        return views
+        
+
     @auth_required
     def post(self):
         args = self.post_req_parser.parse_args()
@@ -271,7 +308,7 @@ class ReviewAssignmentAPI(PostReviewAssignmentMixin, restful.Resource):
         
         return {}, 201
 
-
+    
     def add_reviewer_role(self, user_id, event_id):
         event_role = EventRole('reviewer', user_id, event_id)
         db.session.add(event_role)

--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -11,6 +11,7 @@ from app.responses.models import Response, ResponseReviewer
 from app.reviews.mixins import ReviewMixin, GetReviewResponseMixin, PostReviewResponseMixin, PostReviewAssignmentMixin
 from app.reviews.models import ReviewForm, ReviewResponse, ReviewScore
 from app.users.models import AppUser
+from app.users.repository import UserRepository as user_repository
 from app.utils.auth import auth_required
 from app.utils.errors import EVENT_NOT_FOUND, REVIEW_RESPONSE_NOT_FOUND, FORBIDDEN, USER_NOT_FOUND
 
@@ -252,11 +253,11 @@ class ReviewAssignmentAPI(PostReviewAssignmentMixin, restful.Resource):
         reviewer_user_email = args['reviewer_user_email']
         num_reviews = args['num_reviews']
 
-        current_user = db.session.query(AppUser).get(user_id)
+        current_user = user_repository.get_by_id(user_id)
         if not current_user.is_event_admin(event_id):
             return FORBIDDEN
         
-        reviewer_user = self.get_reviewer_user(reviewer_user_email)
+        reviewer_user = user_repository.get_by_email(reviewer_user_email)
         if reviewer_user is None:
             return USER_NOT_FOUND
         
@@ -271,9 +272,6 @@ class ReviewAssignmentAPI(PostReviewAssignmentMixin, restful.Resource):
         return {}, 201
 
 
-    def get_reviewer_user(self, reviewer_user_email):
-        return db.session.query(AppUser).filter_by(email=reviewer_user_email).first()
-    
     def add_reviewer_role(self, user_id, event_id):
         event_role = EventRole('reviewer', user_id, event_id)
         db.session.add(event_role)

--- a/api/app/reviews/mixins.py
+++ b/api/app/reviews/mixins.py
@@ -18,6 +18,9 @@ class PostReviewResponseMixin(object):
     post_req_parser.add_argument('response_id', type=int, required=True)
     post_req_parser.add_argument('scores', type=dict, required=True, action='append')
 
+class GetReviewAssignmentMixin(object):
+    get_req_parser = reqparse.RequestParser()
+    get_req_parser.add_argument('event_id', type=int, required=True)
 
 class PostReviewAssignmentMixin(object):
     post_req_parser = reqparse.RequestParser()

--- a/api/app/reviews/repository.py
+++ b/api/app/reviews/repository.py
@@ -1,0 +1,21 @@
+from sqlalchemy.sql import func
+from sqlalchemy import and_
+
+from app import db
+from app.applicationModel.models import ApplicationForm
+from app.responses.models import ResponseReviewer, Response
+from app.reviews.models import ReviewResponse, ReviewForm
+from app.users.models import AppUser
+
+class ReviewRepository():
+
+    @staticmethod
+    def count_reviews_allocated_and_completed_per_reviewer(event_id):
+        return db.session.query(AppUser.email, AppUser.user_title, AppUser.firstname, AppUser.lastname, func.count(ResponseReviewer.response_id).label('reviews_allocated'), func.count(ReviewResponse.response_id).label('reviews_completed'))\
+                        .join(ResponseReviewer, ResponseReviewer.reviewer_user_id==AppUser.id)\
+                        .join(Response, Response.id==ResponseReviewer.response_id)\
+                        .join(ApplicationForm, ApplicationForm.id==Response.application_form_id)\
+                        .filter_by(event_id=event_id)\
+                        .outerjoin(ReviewResponse, and_(ReviewResponse.response_id==ResponseReviewer.response_id, ReviewResponse.reviewer_user_id==ResponseReviewer.reviewer_user_id))\
+                        .group_by(ResponseReviewer.reviewer_user_id, AppUser.email, AppUser.user_title, AppUser.firstname, AppUser.lastname)\
+                        .all()

--- a/api/app/reviews/tests.py
+++ b/api/app/reviews/tests.py
@@ -45,17 +45,9 @@ class ReviewsApiTest(ApiTestCase):
         candidate4 = AppUser('c4@c.com', 'candidate', '4', 'Ms', 7, 8, 'F', 'NWU', 'Math', 'NA', 4, datetime(1984, 12, 12), 'Eng', 'abc')
         system_admin = AppUser('sa@sa.com', 'system_admin', '1', 'Ms', 7, 8, 'F', 'NWU', 'Math', 'NA', 4, datetime(1984, 12, 12), 'Eng', 'abc', True)
         event_admin = AppUser('ea@ea.com', 'event_admin', '1', 'Ms', 7, 8, 'F', 'NWU', 'Math', 'NA', 4, datetime(1984, 12, 12), 'Eng', 'abc')
-        reviewer1.verify()
-        reviewer2.verify()
-        reviewer3.verify()
-        reviewer4.verify()
-        candidate1.verify()
-        candidate2.verify()
-        candidate3.verify()
-        candidate4.verify()
-        system_admin.verify()
-        event_admin.verify()
         users = [reviewer1, reviewer2, reviewer3, reviewer4, candidate1, candidate2, candidate3, candidate4, system_admin, event_admin]
+        for user in users:
+            user.verify()
         db.session.add_all(users)
         db.session.commit()
 

--- a/api/app/users/repository.py
+++ b/api/app/users/repository.py
@@ -9,6 +9,10 @@ class UserRepository():
         return db.session.query(AppUser).get(user_id)
 
     @staticmethod
+    def get_by_email(email):
+        return db.session.query(AppUser).filter_by(email=email).first()
+
+    @staticmethod
     def get_all_with_unsubmitted_response():
         return db.session.query(AppUser)\
                          .filter_by(active=True, is_deleted=False)\


### PR DESCRIPTION
Resolves issue #225 

Note I haven't been able to figure out how to include reviewers not allocated to any responses for a particular event (so they might be allocated to another event). If it's necessary, let me know if you have any suggestions for how to go about doing that. 