### PR TITLE
basestring was removed in Python 3 --> six.string_types

### DIFF
--- a/api/app/invitationletter/generator.py
+++ b/api/app/invitationletter/generator.py
@@ -12,6 +12,7 @@ from app import db
 from app.utils import errors
 
 from google.oauth2 import service_account
+from six import string_types
 
 INVITATION_EMAIL_BODY = """
 Dear {user_title} {first_name} {last_name},
@@ -55,26 +56,26 @@ def download_blob(bucket_name, source_blob_name, destination_file_name):
 def check_values(template_path, event_id, work_address, addressed_to, residential_address, passport_name,
         passport_no, passport_issued_by, invitation_letter_sent_at, to_date, from_date, country_of_residence,
         nationality, date_of_birth, email, user_title, firstname, lastname, bringing_poster, expiry_date):
-    assert template_path is not None and isinstance(template_path, basestring) 
+    assert template_path is not None and isinstance(template_path, string_types) 
     assert event_id is not None and isinstance(event_id, int) 
-    assert work_address is not None and isinstance(work_address, basestring) 
-    assert addressed_to is not None and isinstance(addressed_to, basestring) 
-    assert residential_address is not None and isinstance(residential_address, basestring) 
-    assert passport_name is not None and isinstance(passport_name, basestring) 
-    assert passport_no is not None and isinstance(passport_no, basestring) 
-    assert passport_issued_by is not None and isinstance(passport_issued_by, basestring) 
-    assert invitation_letter_sent_at is not None and isinstance(invitation_letter_sent_at, basestring) 
-    assert to_date is not None and isinstance(to_date, basestring) 
-    assert from_date is not None and isinstance(from_date, basestring) 
-    assert country_of_residence is not None and isinstance(country_of_residence, basestring) 
-    assert nationality is not None and isinstance(nationality, basestring) 
-    assert date_of_birth is not None and isinstance(date_of_birth, basestring) 
-    assert email is not None and isinstance(email, basestring) 
-    assert user_title is not None and isinstance(user_title, basestring) 
-    assert firstname is not None and isinstance(firstname, basestring) 
-    assert lastname is not None and isinstance(lastname, basestring) 
-    assert bringing_poster is not None and isinstance(bringing_poster, basestring) 
-    assert expiry_date is not None and isinstance(expiry_date, basestring) 
+    assert work_address is not None and isinstance(work_address, string_types) 
+    assert addressed_to is not None and isinstance(addressed_to, string_types) 
+    assert residential_address is not None and isinstance(residential_address, string_types) 
+    assert passport_name is not None and isinstance(passport_name, string_types) 
+    assert passport_no is not None and isinstance(passport_no, string_types) 
+    assert passport_issued_by is not None and isinstance(passport_issued_by, string_types) 
+    assert invitation_letter_sent_at is not None and isinstance(invitation_letter_sent_at, string_types) 
+    assert to_date is not None and isinstance(to_date, string_types) 
+    assert from_date is not None and isinstance(from_date, string_types) 
+    assert country_of_residence is not None and isinstance(country_of_residence, string_types) 
+    assert nationality is not None and isinstance(nationality, string_types) 
+    assert date_of_birth is not None and isinstance(date_of_birth, string_types) 
+    assert email is not None and isinstance(email, string_types) 
+    assert user_title is not None and isinstance(user_title, string_types) 
+    assert firstname is not None and isinstance(firstname, string_types) 
+    assert lastname is not None and isinstance(lastname, string_types) 
+    assert bringing_poster is not None and isinstance(bringing_poster, string_types) 
+    assert expiry_date is not None and isinstance(expiry_date, string_types) 
 
 
 def generate(template_path, event_id, work_address, addressed_to, residential_address, passport_name,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -23,7 +23,7 @@ passlib>=1.6.2
 py-bcrypt>=0.4
 pytz>=2014.4
 redis>=2.10.3
-six>=1.7.3
+six>=1.14.0
 flask-cors>=3.0.7
 python-dateutil>=2.8.0
 gunicorn==19.5.0


### PR DESCRIPTION
These changes use [__six__](https://pypi.org/project/six/) to be compatible with both Python 2 and Python 3.