### PR TITLE
Fix KeyError: '72548fc390d4'

### DIFF
--- a/api/migrations/versions/d80784e674a8_.py
+++ b/api/migrations/versions/d80784e674a8_.py
@@ -8,7 +8,7 @@ Create Date: 2020-02-17 12:35:15.131604
 
 # revision identifiers, used by Alembic.
 revision = 'd80784e674a8'
-down_revision = ('72548fc390d4', 'f8ab033698a2', '8ba06d0a54ee')
+down_revision = ('f8ab033698a2', '8ba06d0a54ee')
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
Fixes the `KeyError: '72548fc390d4'` on the main develop branch