### PR TITLE
Add space between cookie text and privacy policy

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -520,7 +520,7 @@ class AppComponent extends Component {
           >
             <h5>{t('cookieTitle')}</h5>
             <span style={{ fontSize: "0.8em" }}>
-              {t('cookieText')}
+              {t('cookieText')}{" "}
               <a
                 href={
                   "/" +


### PR DESCRIPTION
This is how it currently looks without the space:

![image](https://user-images.githubusercontent.com/958800/106203142-9c13ea80-61c3-11eb-8921-e6d7a575d6e3.png)
