### PR TITLE
Feature/formatting2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+text=auto eol=lf
+
+*.{png,pdf,ico,enc,jpg,jpeg,gif,webp,woff,woff2} binary

--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,6 @@ venv.bak/
 .spyderproject
 .spyproject
 
-# VSCode project settings
-.vscode
-
-
 # IntelliJ/Pycharm/Webstorm/etc. project settings
 .iml
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig"
+    ]
+}


### PR DESCRIPTION
- Added `.gitattributes` file to force repo to always use `LF` line endings. On the `feature/formatting-applied` branch also ran `git add --renormalize .` to [convert](https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/#a-simple-gitattributes-config) the existing `CRLF` to LF