### PR TITLE
Fix display of uploaded files when editing registration

### DIFF
--- a/webapp/src/pages/registration/components/GuestRegistrationComponent.js
+++ b/webapp/src/pages/registration/components/GuestRegistrationComponent.js
@@ -385,7 +385,7 @@ class GuestRegistrationComponent extends Component {
               id={`control_${question.id}`}
               name={`control_${question.id}`}
               description={question.description}
-              value={this.props.answer && this.props.answer.value}
+              value={answer && answer.value}
               validationError={validationError}
               onChange={(_, v) => this.onChange(question.id, v)}
               key={"i_" + key} />

--- a/webapp/src/pages/registration/components/RegistrationComponent.js
+++ b/webapp/src/pages/registration/components/RegistrationComponent.js
@@ -416,7 +416,7 @@ class RegistrationComponent extends Component {
               id={`control_${question.id}`}
               name={`control_${question.id}`}
               description={question.description}
-              value={this.props.answer && this.props.answer.value}
+              value={answer && answer.value}
               validationError={validationError}
               onChange={(_, v) => this.onChange(question.id, v)}
               key={"i_" + key} />


### PR DESCRIPTION
Fixed display of uploaded files at registration and guest registration. The uploaded file is clickable and should download.

Before
![before](https://github.com/deep-learning-indaba/Baobab/assets/7526106/291ead51-6b54-4c3b-8de0-797116151f8f)

After
![after](https://github.com/deep-learning-indaba/Baobab/assets/7526106/59562b18-e4e8-421c-b8a2-355d5e8bd7c3)

cc @smhall97 
