### PR TITLE
DB changes: Added two fields to reviews models for continuous journals

### DIFF
--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -958,6 +958,7 @@ class ReviewFormDetailAPI(restful.Resource):
         req_parser.add_argument('deadline', type=dt_format, required=True)
         req_parser.add_argument('active', type=bool, required=True)
         req_parser.add_argument('sections', type=dict, required=True, action='append')
+        # req_parser.add_argument('reviewer_type', type=dict, required=True, action='append')
         args = req_parser.parse_args()
 
         application_form_id = args['application_form_id']
@@ -966,6 +967,7 @@ class ReviewFormDetailAPI(restful.Resource):
         deadline = args['deadline']
         active = args['active']
         sections_data = args['sections']
+        # reviewer_type = args['reviewer_type']
 
         review_form = review_repository.get_review_form(event_id, stage)
         if review_form is not None:
@@ -978,8 +980,11 @@ class ReviewFormDetailAPI(restful.Resource):
             deadline, 
             stage, 
             # Only make this stage active if there is no other active stage.
-            active=not any(o.active for o in other_review_forms))
-        
+            active=not any(o.active for o in other_review_forms),
+            reviewer_type="Reviewer")
+            # reviewer_type="Meta-reviewer")
+            # reviewer_type=reviewer_type)
+
         review_repository.add_model(review_form)
 
         for section_data in sections_data:

--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -1007,7 +1007,9 @@ class ReviewFormDetailAPI(restful.Resource):
                     type=question_data['type'],
                     is_required=question_data['is_required'],
                     order=question_data['order'],
-                    weight=question_data['weight'])
+                    weight=question_data['weight'],
+                    # private=question_data['private'])
+                    private=None)
                 
                 review_repository.add_model(question)
 
@@ -1134,7 +1136,9 @@ class ReviewFormDetailAPI(restful.Resource):
                         type=question_data["type"],
                         is_required=question_data["is_required"],
                         order=question_data["order"],
-                        weight=question_data["weight"])
+                        weight=question_data["weight"],
+                        # private=question_data['private'])
+                        private=None)
 
                     review_repository.add_model(question)
 

--- a/api/app/reviews/api.py
+++ b/api/app/reviews/api.py
@@ -981,7 +981,7 @@ class ReviewFormDetailAPI(restful.Resource):
             stage, 
             # Only make this stage active if there is no other active stage.
             active=not any(o.active for o in other_review_forms),
-            reviewer_type="Reviewer")
+            reviewer_type=None)
             # reviewer_type="Meta-reviewer")
             # reviewer_type=reviewer_type)
 

--- a/api/app/reviews/models.py
+++ b/api/app/reviews/models.py
@@ -12,16 +12,18 @@ class ReviewForm(db.Model):
     deadline = db.Column(db.DateTime(), nullable=False)
     stage = db.Column(db.Integer(), nullable=False)
     active = db.Column(db.Boolean(), nullable=False)
+    reviewer_type = db.Column(db.String(), nullable=True)
 
     application_form = db.relationship('ApplicationForm', foreign_keys=[application_form_id])
     review_sections = db.relationship('ReviewSection', order_by='ReviewSection.order')
 
-    def __init__(self, application_form_id, deadline, stage, active):
+    def __init__(self, application_form_id, deadline, stage, active, reviewer_type):
         self.application_form_id = application_form_id
         self.is_open = True
         self.deadline = deadline
         self.stage = stage
         self.active = active
+        self.reviewer_type = reviewer_type
 
     def close(self):
         self.is_open = False

--- a/api/app/reviews/models.py
+++ b/api/app/reviews/models.py
@@ -93,15 +93,14 @@ class ReviewQuestion(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     review_section_id = db.Column(db.Integer(), db.ForeignKey('review_section.id'), nullable=False)
     question_id = db.Column(db.Integer(), db.ForeignKey('question.id'), nullable=True)
-
     type = db.Column(db.String(), nullable=False)
-
     is_required = db.Column(db.Boolean(), nullable=False)
     order = db.Column(db.Integer(), nullable=False)
     weight = db.Column(db.Float(), nullable=False)
+    private = db.Column(db.Boolean(), nullable=True)
+
     review_section = db.relationship('ReviewSection', foreign_keys=[review_section_id])
     question = db.relationship('Question', foreign_keys=[question_id])
-
     translations = db.relationship('ReviewQuestionTranslation', lazy='dynamic')
 
     def __init__(self,
@@ -110,13 +109,15 @@ class ReviewQuestion(db.Model):
                  type,
                  is_required,
                  order,
-                 weight):
+                 weight,
+                 private):
         self.review_section_id = review_section_id
         self.question_id = question_id
         self.type = type
         self.is_required = is_required
         self.order = order
         self.weight = weight
+        self.private = private
 
     def get_translation(self, language):
         translation = self.translations.filter_by(language=language).first()

--- a/api/migrations/versions/ccc42bf54796_review_question_add_private_field.py
+++ b/api/migrations/versions/ccc42bf54796_review_question_add_private_field.py
@@ -1,0 +1,26 @@
+"""
+Added a Boolean field called ``private`` to review_question table.
+Null if the event TYPE is not CONTINUOUS_JOURNAL.
+It is used to specify whether the question from the reviewer 
+is private (True) or public (False).
+
+Revision ID: ccc42bf54796
+Revises: e30a22a1abf6
+Create Date: 2023-07-26 15:56:00.173322
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ccc42bf54796'
+down_revision = 'e30a22a1abf6'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('review_question', sa.Column('private', sa.Boolean(), nullable=True))
+    
+
+def downgrade():
+    op.drop_column('review_question', 'private')

--- a/api/migrations/versions/e30a22a1abf6_review_form_add_type_field.py
+++ b/api/migrations/versions/e30a22a1abf6_review_form_add_type_field.py
@@ -1,0 +1,24 @@
+"""
+Added a field called ``reviewer_type`` to review_form table.
+Null if the event TYPE is not CONTINUOUS_JOURNAL.
+It is used to specify whether the reviewer is a 'Meta-reviewer' or a normal 'Reviewer'.
+
+Revision ID: e30a22a1abf6
+Revises: 9143756e596d
+Create Date: 2023-07-26 12:30:18.181998
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e30a22a1abf6'
+down_revision = '9143756e596d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('review_form', sa.Column('reviewer_type', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('review_form', 'reviewer_type')


### PR DESCRIPTION
@amritpurshotam  Hi Amrit, in this PR I added a new field to the review form table called `reviewer_type`. It is a string field which is used when the review form related to an `Event` of the type `CONTINUOUS_JOURNAL`. The value of `reviewer_type` should be `None` if the event type is continuous journal. If the event is a continuous journal, then the value of `reviewer_type` should be either "Meta-reviewer" or "Reviewer".

Let me know what you think and if I should change anything. I'll start with some other PRs in the meantime.