### PR TITLE
Shifting to tag-based functionality for registration questions & attendance/check-in

### DIFF
--- a/api/app/guestRegistrations/repository.py
+++ b/api/app/guestRegistrations/repository.py
@@ -94,9 +94,9 @@ class GuestRegistrationRepository():
                         .order_by(cast(GuestRegistration.created_at, Date))
                         .all())
         return timeseries
-
+    
     @staticmethod
-    def get_guest_registration_answer_by_headline(user_id, event_id, headline):
+    def get_guest_registration_answer_by_question_id(user_id, event_id, question_id):
         answer = (
             db.session.query(GuestRegistrationAnswer)
             .join(GuestRegistration, GuestRegistrationAnswer.guest_registration_id == GuestRegistration.id)
@@ -104,7 +104,7 @@ class GuestRegistrationRepository():
             .join(RegistrationForm, GuestRegistration.registration_form_id == RegistrationForm.id)
             .filter_by(event_id=event_id)
             .join(RegistrationQuestion, GuestRegistrationAnswer.registration_question_id == RegistrationQuestion.id)
-            .filter_by(headline=headline)
+            .filter_by(id=question_id)
             .first())
         return answer
     

--- a/api/app/registration/api.py
+++ b/api/app/registration/api.py
@@ -14,7 +14,6 @@ from flask_restful import  fields, marshal_with, marshal
 from sqlalchemy.exc import SQLAlchemyError
 from app.events.models import Event
 from app.tags.models import Tag, TagType
-from app.tags.api import TagAPI
 from app.registration.models import Offer, OfferTag
 from app.registration.mixins import OfferMixin
 from app.users.models import AppUser
@@ -202,7 +201,7 @@ class OfferAPI(OfferMixin, restful.Resource):
         db.session.commit()
         
         if grant_tags:
-            grant_strs = [TagAPI._stringify_tag_name_description(offer_tag.tag) for offer_tag in offer_entity.offer_tags]
+            grant_strs = [offer_tag.tag.stringify_tag_name_description() for offer_tag in offer_entity.offer_tags]
             grants_summary = "\n\u2022 " + "\n\u2022 ".join(grant_strs)
             email_template = 'offer-grants'
         else:

--- a/api/app/registration/api.py
+++ b/api/app/registration/api.py
@@ -14,6 +14,7 @@ from flask_restful import  fields, marshal_with, marshal
 from sqlalchemy.exc import SQLAlchemyError
 from app.events.models import Event
 from app.tags.models import Tag, TagType
+from app.tags.api import TagAPI
 from app.registration.models import Offer, OfferTag
 from app.registration.mixins import OfferMixin
 from app.users.models import AppUser
@@ -27,7 +28,6 @@ from app.outcome.repository import OutcomeRepository as outcome_repository
 from app.responses.repository import ResponseRepository as response_repository
 from app.registration.repository import OfferRepository as offer_repository
 from app.registration.repository import RegistrationRepository as registration_repository
-from app.users.repository import UserRepository as user_repository
 
 def offer_info(offer_entity, requested_travel=None):
     return {
@@ -96,14 +96,6 @@ class OfferAPI(OfferMixin, restful.Resource):
             'description': translation.description,
             'accepted': offer_tag.accepted
         }
-
-    @staticmethod
-    def _stringify_tag_name_description(offer_tag, language='en'):
-        translation = offer_tag.tag.get_translation(language)
-        if translation is None:
-            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, offer_tag.tag.id))
-            translation = offer_tag.tag.get_translation('en')
-        return '{}: {}'.format(translation.name, translation.description)
 
     @auth_required
     def put(self):
@@ -210,7 +202,7 @@ class OfferAPI(OfferMixin, restful.Resource):
         db.session.commit()
         
         if grant_tags:
-            grant_strs = [OfferAPI._stringify_tag_name_description(offer_tag) for offer_tag in offer_entity.offer_tags]
+            grant_strs = [TagAPI._stringify_tag_name_description(offer_tag.tag) for offer_tag in offer_entity.offer_tags]
             grants_summary = "\n\u2022 " + "\n\u2022 ".join(grant_strs)
             email_template = 'offer-grants'
         else:

--- a/api/app/registration/models.py
+++ b/api/app/registration/models.py
@@ -93,18 +93,16 @@ class RegistrationSection(db.Model):
         self.show_for_tag_id = show_for_tag_id
         self.show_for_invited_guest = show_for_invited_guest
 
-
-def get_registration_answer_based_headline(user_id, event_id, headline):
-    answer = (
-        db.session.query(RegistrationAnswer)
-        .join(Registration, RegistrationAnswer.registration_id == Registration.id)
-        .join(Offer, Offer.id == Registration.offer_id)
-        .filter_by(user_id=user_id, event_id=event_id)
-        .join(RegistrationQuestion, RegistrationAnswer.registration_question_id == RegistrationQuestion.id)
-        .filter_by(headline=headline)
-        .first())
-    return answer
-
+def get_registration_answer_by_question_id(user_id, event_id, question_id):
+        answer = (
+            db.session.query(RegistrationAnswer)
+            .join(Registration, RegistrationAnswer.registration_id == Registration.id)
+            .join(Offer, Offer.id == Registration.offer_id)
+            .filter_by(user_id=user_id, event_id=event_id)
+            .join(RegistrationQuestion, RegistrationAnswer.registration_question_id == RegistrationQuestion.id)
+            .filter_by(id=question_id)
+            .first())
+        return answer
 
 class RegistrationQuestion(db.Model):
 

--- a/api/app/registration/models.py
+++ b/api/app/registration/models.py
@@ -129,6 +129,8 @@ class RegistrationQuestion(db.Model):
         "registration_question.id"), nullable=True)
     hide_for_dependent_value = db.Column(db.String(), nullable=True)
 
+    tags = db.relationship('RegistrationQuestionTag')
+
     def __init__(self, registration_form_id, section_id, headline, placeholder, order, type, validation_regex, validation_text=None, is_required=True, description=None, options=None):
         self.registration_form_id = registration_form_id
         self.section_id = section_id
@@ -142,8 +144,19 @@ class RegistrationQuestion(db.Model):
         self.validation_regex = validation_regex
         self.validation_text = validation_text
 
-# Registration
+class RegistrationQuestionTag(db.Model):
+    id = db.Column(db.Integer(), primary_key=True)
+    registration_question_id = db.Column(db.Integer(), db.ForeignKey('registration_question.id'), nullable=False)
+    tag_id = db.Column(db.Integer(), db.ForeignKey('tag.id'), nullable=False)
 
+    registration_question = db.relationship('RegistrationQuestion', foreign_keys=[registration_question_id])
+    tag = db.relationship('Tag', foreign_keys=[tag_id])
+
+    def __init__(self, registration_question_id, tag_id):
+        self.registration_question_id = registration_question_id
+        self.tag_id = tag_id
+
+# Registration
 
 class Registration(db.Model):
     __tablename__ = "registration"

--- a/api/app/registration/repository.py
+++ b/api/app/registration/repository.py
@@ -115,7 +115,7 @@ class RegistrationFormRepository():
 
     @staticmethod
     def get_registration_questions_with_tags(event_id):
-        """Get all questions with active tags in a registration."""
+        """Get all questions with active tags in a registration form."""
         return db.session.query(RegistrationQuestion).join(
                 RegistrationForm, RegistrationQuestion.registration_form_id == RegistrationForm.id).filter(
                     RegistrationForm.event_id == event_id).filter(

--- a/api/app/registration/repository.py
+++ b/api/app/registration/repository.py
@@ -1,5 +1,6 @@
 from app import db
-from app.registration.models import Offer, Registration, RegistrationForm, OfferTag
+from app.registration.models import Offer, Registration, RegistrationForm, RegistrationQuestion, OfferTag
+from app.tags.models import Tag
 from sqlalchemy import and_, func, cast, Date
 
 
@@ -101,7 +102,6 @@ class RegistrationRepository():
     def get_form_for_event(event_id):
         return (db.session.query(RegistrationForm).filter_by(event_id=event_id)).first()
 
-
 class RegistrationFormRepository():
     @staticmethod
     def get_by_event_id(event_id):
@@ -112,5 +112,15 @@ class RegistrationFormRepository():
     @staticmethod
     def get_by_id(id):
         return db.session.query(RegistrationForm).get(id)
+
+    @staticmethod
+    def get_registration_questions_with_tags(event_id):
+        """Get all questions with active tags in a registration."""
+        return db.session.query(RegistrationQuestion).join(
+                RegistrationForm, RegistrationQuestion.registration_form_id == RegistrationForm.id).filter(
+                    RegistrationForm.event_id == event_id).filter(
+                    RegistrationQuestion.tags != None).join(
+                    Tag, RegistrationQuestion.tags.any(Tag.active == True)
+            ).all()
     
     

--- a/api/app/registrationResponse/repository.py
+++ b/api/app/registrationResponse/repository.py
@@ -1,11 +1,9 @@
 from app import db
 from app.registration.models import Offer, Registration
+from app.tags.models import Tag
 from app.users.models import AppUser
-from app.events.models import Event
 from app.attendance.models import Attendance
 from sqlalchemy.sql import exists
-from app import LOGGER
-
 
 class RegistrationRepository():
 

--- a/api/app/tags/api.py
+++ b/api/app/tags/api.py
@@ -109,22 +109,6 @@ class TagAPI(restful.Resource):
         tag_repository.commit()
 
         return _serialize_tag_detail(tag), 200
-
-    @staticmethod
-    def _stringify_tag_name_description(tag, language='en'):
-        translation = tag.get_translation(language)
-        if translation is None:
-            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, tag.id))
-            translation = tag.get_translation('en')
-        return '{}: {}'.format(translation.name, translation.description)
-
-    @staticmethod
-    def _stringify_tag_name(tag, language='en'):
-        translation = tag.get_translation(language)
-        if translation is None:
-            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, tag.id))
-            translation = tag.get_translation('en')
-        return '{}'.format(translation.name)
     
 class TagListAPI(restful.Resource):
     @event_admin_required

--- a/api/app/tags/api.py
+++ b/api/app/tags/api.py
@@ -109,6 +109,22 @@ class TagAPI(restful.Resource):
         tag_repository.commit()
 
         return _serialize_tag_detail(tag), 200
+
+    @staticmethod
+    def _stringify_tag_name_description(tag, language='en'):
+        translation = tag.get_translation(language)
+        if translation is None:
+            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, tag.id))
+            translation = tag.get_translation('en')
+        return '{}: {}'.format(translation.name, translation.description)
+
+    @staticmethod
+    def _stringify_tag_name(tag, language='en'):
+        translation = tag.get_translation(language)
+        if translation is None:
+            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, tag.id))
+            translation = tag.get_translation('en')
+        return '{}'.format(translation.name)
     
 class TagListAPI(restful.Resource):
     @event_admin_required

--- a/api/app/tags/models.py
+++ b/api/app/tags/models.py
@@ -1,5 +1,6 @@
 from app import db
 from enum import Enum
+from app import LOGGER
 
 class TagType(Enum):
     RESPONSE = 'response'
@@ -33,6 +34,20 @@ class Tag(db.Model):
     def get_translation(self, language):
         translation = self.translations.filter_by(language=language).first()
         return translation
+
+    def stringify_tag_name_description(self, language='en'):
+        translation = self.get_translation(language)
+        if translation is None:
+            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, self.tag.id))
+            translation = self.tag.get_translation('en')
+        return '{}: {}'.format(translation.name, translation.description)
+
+    def stringify_tag_name(self, language='en'):
+        translation = self.get_translation(language)
+        if translation is None:
+            LOGGER.warn('Could not find {} translation for tag id {}'.format(language, self.tag.id))
+            translation = self.tag.get_translation('en')
+        return '{}'.format(translation.name)
 
 class TagTranslation(db.Model):
     __tablename__ = 'tag_translation'

--- a/api/app/tags/models.py
+++ b/api/app/tags/models.py
@@ -5,6 +5,7 @@ class TagType(Enum):
     RESPONSE = 'response'
     REGISTRATION = 'registration'
     GRANT = 'grant'
+    QUESTION = 'question'
 
 class Tag(db.Model):
     __tablename__ = 'tag'

--- a/api/migrations/versions/478d1ac3d0ed_addquestiontagmodel.py
+++ b/api/migrations/versions/478d1ac3d0ed_addquestiontagmodel.py
@@ -1,0 +1,41 @@
+"""Add question tag model
+
+Revision ID: 478d1ac3d0ed
+Revises: 9143756e596d
+Create Date: 2023-08-20 09:31:29.616347
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '478d1ac3d0ed'
+down_revision = '9143756e596d'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('registration_question_tag',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('registration_question_id', sa.Integer(), nullable=False),
+    sa.Column('tag_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['registration_question_id'], ['registration_question.id'], ),
+    sa.ForeignKeyConstraint(['tag_id'], ['tag.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    #op.create_foreign_key('registration_question_registration_question_tag_id_fkey', 'registration_question', 'registration_question_tag', ['id'], ['registration_question_id'])
+    
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE tag_type ADD VALUE 'QUESTION'")
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_table('registration_question_tag')
+    #op.drop_constraint('registration_question_registration_question_tag_id_fkey', 'registration_question', type_='foreignkey')
+    
+    op.execute("""DELETE FROM pg_enum
+        WHERE enumlabel = 'QUESTION'
+        AND enumtypid = (
+        SELECT oid FROM pg_type WHERE typname = 'tag_type'
+        )""")
+    # ### end Alembic commands ###

--- a/webapp/src/pages/ResponseList/components/ResponseListComponent.js
+++ b/webapp/src/pages/ResponseList/components/ResponseListComponent.js
@@ -219,7 +219,7 @@ class ResponseListComponent extends Component {
             reviewerAssignError,
             newReviewerEmail,
             reviewerAssignSuccess,
-            tags,
+            filteredTags,
             filteredResponses
         } = this.state
 
@@ -337,7 +337,7 @@ class ResponseListComponent extends Component {
                               closeMenuOnSelect={false}
                               components={animatedComponents}
                               isMulti
-                              options={this.getSearchTags(tags)}
+                              options={this.getSearchTags(filteredTags)}
                               id="TagFilter"
                               placeholder="Search"
                               onChange={this.updateTagSearch}

--- a/webapp/src/pages/attendance/components/AttendanceTable.js
+++ b/webapp/src/pages/attendance/components/AttendanceTable.js
@@ -272,13 +272,15 @@ class AttendanceTable extends React.Component {
               <div className={this.styleFromRole(selectedUser.invitedguest_role)}>
                 {selectedUser.invitedguest_role}
               </div>
-            </h5>
-            <h5>
-              T-Shirt Size :
-              <div className="badge badge-light">
-                {selectedUser.shirt_size}
-              </div>
-            </h5>
+            </h5>              
+            {selectedUser.registration_metadata.map((i) => (
+              <h5>
+                {i.name} :
+                <div className="badge badge-light">
+                  {i.response}
+                </div>
+              </h5>
+            ))}
             <h5>
               Indemnity Form :
               {selectedUser.signed_indemnity_form && <div className="badge badge-success">

--- a/webapp/src/pages/attendance/components/AttendanceTable.js
+++ b/webapp/src/pages/attendance/components/AttendanceTable.js
@@ -302,7 +302,7 @@ class AttendanceTable extends React.Component {
             <button 
               type="submit" 
               className="btn btn-primary confirm-submit"
-              disabled={!(selectedUser.signed_indemnity_form || signedIndemnityChecked)} 
+              disabled={!(selectedUser.signed_indemnity_form || signedIndemnityChecked) || !selectedUser.confirmed} 
               onClick={this.onConfirm}>
                 Confirm
             </button>

--- a/webapp/src/pages/registration/components/RegistrationComponent.js
+++ b/webapp/src/pages/registration/components/RegistrationComponent.js
@@ -169,7 +169,7 @@ class RegistrationComponent extends Component {
                   });
                 }
                 else {
-                  this.setStats({
+                  this.setState({
                     error: result.error,
                     isLoading: false
                   });

--- a/webapp/src/pages/reviewAssignment/components/ReviewAssignmentComponent.js
+++ b/webapp/src/pages/reviewAssignment/components/ReviewAssignmentComponent.js
@@ -13,6 +13,8 @@ class ReviewAssignmentComponent extends Component {
   constructor(props) {
     super(props);
 
+    this.filterable_tag_types = ["RESPONSE"];
+
     this.state = {
       loading: true,
       reviewers: null,
@@ -33,7 +35,7 @@ class ReviewAssignmentComponent extends Component {
         reviewService.getReviewSummary(event_id, tags)
     ]).then(responses => {
         this.setState({
-            tags: responses[0].tags.map(tag => { return { ...tag, active: false } }),
+            tags: responses[0].tags.filter(tag => this.filterable_tag_types.includes(tag.tag_type)).map(tag => { return { ...tag, active: false } }),
             reviewers: responses[1].reviewers,
             reviewSummary: responses[2].reviewSummary,
             newReviewerEmail: "",

--- a/webapp/src/pages/tagConfig/components/TagConfigComponent.js
+++ b/webapp/src/pages/tagConfig/components/TagConfigComponent.js
@@ -8,7 +8,6 @@ import FormSelect from "../../../components/form/FormSelect";
 import ReactTable from 'react-table';
 import { ConfirmModal } from "react-bootstrap4-modal";
 
-//TODO not auto loading when tag is added or edited
 //TODO test multilingual language
 
 class TagConfigComponent extends Component {


### PR DESCRIPTION
Included in this PR:
- A change in the way answers to registration questions are extracted and attached to an AttendanceUser. Previously a user's answers were extracted by searching for specific question strings (e.g. 'Are you bringing a poster?'). This PR instead adds functionality for answers to be extracted by a tag attached to a question. Specifically, for a given user, all the registration questions that have been tagged by an admin (functionality to do this is not included in this PR, though a new tag_type = QUESTION has been added) are pulled from the dataset, and then their corresponding answers are extracted.
- Added a new RegistrationQuestionTag model
- Removed accommodation award, tshirt and poster fields from attendance, in place of a `registration_metadata` and `offer_metadata` fields which are lists of dicts containing relevant info. `registration_metadaset` contains name/response pairs for all the registration questions which had tags and the user's corresponding answers. `offer_metadata` just extracts the names of the tags attaches to the user's offer.
- The front-end check-in functionality then simply loops through the `registration_metadata`, and displays it. Currently, the `offer_metadata` is not shown though can easily be added.
- Shifted some tag stringify functionality to the TagAPI class (from the OfferAPI class), so it can be used more broadly
- Some small bug and comment fixes

I have tested this very briefly. Will continue testing over the next days.