### PR TITLE
Drop enum value safely

### DIFF
--- a/api/migrations/versions/e511f343cb08_complete_removal_of_continuous_journal.py
+++ b/api/migrations/versions/e511f343cb08_complete_removal_of_continuous_journal.py
@@ -15,11 +15,12 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.execute("""DELETE FROM pg_enum
-        WHERE enumlabel = 'CONTINUOUS_JOURNAL' 
-        AND enumtypid = (
-        SELECT oid FROM pg_type WHERE typname = 'event_type'
-        )""")
+    # https://blog.yo1.dog/updating-enum-values-in-postgresql-the-safe-and-easy-way/
+    op.execute("UPDATE event SET event_type = 'JOURNAL' WHERE event_type = 'CONTINUOUS_JOURNAL'")
+    op.execute("ALTER TYPE event_type RENAME TO event_type_old")
+    op.execute("CREATE TYPE event_type AS ENUM('EVENT', 'AWARD', 'CALL', 'PROGRAMME', 'JOURNAL')")
+    op.execute("ALTER TABLE event ALTER COLUMN event_type TYPE event_type USING event_type::text::event_type")
+    op.execute("DROP TYPE event_type_old")
 
 
 def downgrade():


### PR DESCRIPTION
This attempts to fix the [permission error](https://app.circleci.com/pipelines/github/deep-learning-indaba/Baobab/3098/workflows/ef3d68b1-fcea-4ef8-89f6-fc6df9ee4c0b/jobs/10000?invite=true#step-102-21183_111) when running the migrations in `migrate-test`. The previous way was apparently quite unsafe so the database guarding against this type of query was good! Followed this [guide](https://blog.yo1.dog/updating-enum-values-in-postgresql-the-safe-and-easy-way/) now instead.

We also haven't released so should be fine to modify this migration. 