### PR TITLE
Fixes issue #1361

### DIFF
--- a/webapp/public/locales/en/translation.json
+++ b/webapp/public/locales/en/translation.json
@@ -19,7 +19,7 @@
     "I understand": "I Understand",
     "Uploaded file": "Uploaded file",
     "Other": "Other",
-    "Other - Please Specify": "Other - Please Specify:",
+    "Other - Please Specify": "Other - Please Specify",
     "Word Count": "Word Count",
     "Loading": "Loading",
     "Profile": "Profile",

--- a/webapp/public/locales/fr/translation.json
+++ b/webapp/public/locales/fr/translation.json
@@ -19,7 +19,7 @@
     "I understand": "Je comprends",
     "Uploaded file": "Fichier téléchargé",
     "Other": "Autres",
-    "Other - Please Specify": "Autre, veuillez préciser :",
+    "Other - Please Specify": "Autre, veuillez préciser",
     "Word Count": "Nombre de mots",
     "Loading": "Chargement",
     "Profile": "Profil",


### PR DESCRIPTION
Small fix for a duplicated colon in the "Other - Please Specify" label (shows as "Other - Please Specify::" instead of "Other - Please Specify:").