### PR TITLE
🔒 fix: Replace hardcoded API key with environment variable

### DIFF
--- a/api/app/invoice/generator.py
+++ b/api/app/invoice/generator.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 
 _USDGBP_PATH = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.min.json"
-_API_KEY = 'sk_LexJK2eK0jY3Kmm9gE6R6nJ4M8RwrZpN'
+_API_KEY = os.getenv('INVOICE_GENERATOR_API_KEY')
 
 class InvoiceGenerator:
     URL = "https://invoice-generator.com"


### PR DESCRIPTION
## 📋 Summary

Hardcoded `invoice-generator.com` API key replaced with `os.getenv("INVOICE_GENERATOR_API_KEY")` — following the same pattern already used for `GCP_API_KEY` in `api/app/utils/translation.py`.

**File:** `api/app/invoice/generator.py:12`

**Before:**
```python
_API_KEY = "sk_LexJK2eK0jY3Kmm9gE6R6nJ4M8RwrZpN"
```

**After:**
```python
_API_KEY = os.getenv("INVOICE_GENERATOR_API_KEY")
```

## 📚 Understanding This Vulnerability

### What is it?
Hardcoded credentials (API keys, passwords, tokens) stored directly in source code — visible to anyone with repository access.

### Why it matters
If the code leaks (GitHub, laptop, backup), an attacker gains access to all services using those credentials. Hardcoded secrets are one of the **OWASP Top 10** (A07:2021 — Identification and Authentication Failures) and the **#1 cause of cloud breaches** according to multiple industry reports.

### When it happens
`config.py`, `settings.py`, example code, test fixtures with real data.

### How to fix properly
1. **Environment variables:** `os.getenv("KEY_NAME")`
2. **`.env` file** (gitignored) for local development
3. **Secrets manager** (AWS Secrets Manager, HashiCorp Vault) for production
4. **Rotate the exposed key immediately** — treat it as compromised

### 🧠 Analogy
> A house key under the doormat. Even if nobody sees it — one day someone will check.

### 📖 Further Reading
- [12 Factor App: Config](https://12factor.net/config)
- [OWASP: Hardcoded Secrets](https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password)

---
🐛 Found by [GSC](https://github.com/poliakarmai/gsc) — understand your code, don't just accept it.